### PR TITLE
Chore: Add a section about rosetta being a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ ps-web-apis is a client side library to interface with ps services on ps support
 
 `npm install --save @spring-media/ps-web-apis`
 
+Also needs [ps-rosetta](https://github.com/spring-media/ps-rosetta) to be present on the website:
+
+```html
+<script type="text/javascript" src="https://rosetta.prod.ps.welt.de/ps-rosetta.js"></script>
+```
+
 # Usage
 
 ```javascript


### PR DESCRIPTION
We consistently run into the problem that devs either don't know or forget that rosetta has to be present on the website/frame that wants to use ps-web-apis. 

Fixes #15